### PR TITLE
The mic session is only started once to speed up the recognition lag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This project is a component of korerorero-reverse-proxy project: <https://github.com/ServiceInnovationLab/korerorero-reverse-proxy>
 
+This project has only been tested in Chrome browser. It doesn't work in Safari, and hasn't been tested in Firefox or IE.
+
+Safari needs more work because of deviations from in the Web Audio API spec. Safari needs, at least, browser prefixes for some of the methods in `Recognizer.js`, and perhaps more.
+
 ## Next.js
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app).

--- a/src/components/Recognizer.js
+++ b/src/components/Recognizer.js
@@ -28,6 +28,7 @@ class Recognizer extends Component {
     this.socket.on("connect", () => {
       console.log("socket connected");
       this.setState({ connected: true });
+      this.startRecording();
     });
 
     this.socket.on("disconnect", () => {
@@ -46,54 +47,8 @@ class Recognizer extends Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.isListening === prevProps.isListening) {
-      return;
-    }
-    if (this.props.isListening && this.state.connected) {
-      this.startRecording();
-    } else if (this.state.recording) {
-      this.stopRecording();
-    }
-  }
-
   render() {
-    return (
-      <div className="App">
-        <div>
-          <button
-            disabled={!this.state.connected || this.state.recording}
-            onClick={this.startRecording}
-          >
-            Start Recognizing
-          </button>
-
-          <button disabled={!this.state.recording} onClick={this.stopRecording}>
-            Stop Recognizing
-          </button>
-
-          {this.renderTime()}
-        </div>
-        {this.renderRecognitionOutput()}
-      </div>
-    );
-  }
-
-  renderTime() {
-    return (
-      <span>
-        {(Math.round(this.state.recordingTime / 100) / 10).toFixed(1)}s
-      </span>
-    );
-  }
-
-  renderRecognitionOutput() {
-    if (this.state.recognitionOutput.length === 0) return <></>;
-    return (
-      <ul>
-        <li>{this.state.recognitionOutput[0].text}</li>
-      </ul>
-    );
+    return <></>;
   }
 
   createAudioProcessor(audioContext, audioSource) {
@@ -110,6 +65,7 @@ class Recognizer extends Component {
     };
 
     processor.onaudioprocess = (event) => {
+      if (!this.props.isListening) return;
       var data = event.inputBuffer.getChannelData(0);
       downsampler.postMessage({ command: "process", inputFrame: data });
     };


### PR DESCRIPTION
Just a little change. Start the mic at the beginning of the session and mute/unmute it. It's way faster than setting up and tearing down a whole audio context each time.
Tidied up the UI a bit.
Made a note about browser compatiblity.
As usual, run from here: https://github.com/ServiceInnovationLab/korerorero-reverse-proxy/pull/20